### PR TITLE
[feat] Adjust the default ports for gateway and user

### DIFF
--- a/practices/injection/app/gateway/manifest/config/config.yaml
+++ b/practices/injection/app/gateway/manifest/config/config.yaml
@@ -11,4 +11,4 @@ logger:
 
 # grpc services.
 services:
-  user: "127.0.0.1:8000"
+  user: "127.0.0.1:8001"

--- a/practices/injection/app/user/manifest/config/config.yaml
+++ b/practices/injection/app/user/manifest/config/config.yaml
@@ -1,7 +1,7 @@
 # GRPC Server.
 # https://goframe.org/docs/micro-service/config
 grpc:
-  address: ":8000"
+  address: ":8001"
   logPath: ""
   logStdout: true
   errorStack: true


### PR DESCRIPTION
When running the gateway and user processes on a single machine, using port 8000 for both will cause a port conflict. Therefore, the user application's configuration should be adjusted to use port 8001.